### PR TITLE
feat: user voted indicator

### DIFF
--- a/mesibot-app/src/components/Playlist/SongRow/SongRow.tsx
+++ b/mesibot-app/src/components/Playlist/SongRow/SongRow.tsx
@@ -15,7 +15,10 @@ interface SongRowProps extends SongRowType {
 
 export const SongRow = (props: SongRowProps) => {
   const { connectedUser, playlistId, party } = useAppContext();
-  const { number, title, addedBy, _id } = props;
+  const { number, title, addedBy, _id, downvotedBy, upvotedBy } = props;
+
+  const isDownVotedByUser = downvotedBy.includes(connectedUser!.avatar);
+  const isUpVotedByUser = upvotedBy.includes(connectedUser!.avatar);
 
   return (
     <StyledSongRow>
@@ -32,6 +35,7 @@ export const SongRow = (props: SongRowProps) => {
         <IconButton
           sx={{ color: Colors.goodGreen }}
           size="small"
+          disabled={isUpVotedByUser}
           onClick={() => {
             upvoteSong(party?._id ?? null, _id, connectedUser, playlistId);
           }}
@@ -40,6 +44,7 @@ export const SongRow = (props: SongRowProps) => {
         </IconButton>
         <IconButton
           size="small"
+          disabled={isDownVotedByUser}
           sx={{ color: Colors.vividPink }}
           onClick={() => {
             downvoteSong(party?._id ?? null, _id, connectedUser, playlistId);


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX19vtClHk4qBYBQO6hIFCIbP4R4pbJ5c%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=GvP3vGX)
this feature disables the upvote button if user has already upvoted for a song and vice versa this may be improved later by using actual user ids

<img width="144" alt="image" src="https://github.com/user-attachments/assets/46bc30bd-dc4a-4b69-87ce-a48366aedeea" />
